### PR TITLE
Enhance API resource retrieval methods to support optional inclusion of data and subordinates

### DIFF
--- a/src/litegraph/models/enumeration_query.py
+++ b/src/litegraph/models/enumeration_query.py
@@ -10,8 +10,10 @@ class EnumerationQueryModel(BaseModel):
     ordering: EnumerationOrder_Enum = Field(
         default=EnumerationOrder_Enum.CreatedDescending, alias="Ordering"
     )
-    include_data: bool = Field(default=False, alias="IncludeData")
-    include_subordinates: bool = Field(default=False, alias="IncludeSubordinates")
+    include_data: Optional[bool] = Field(default=False, alias="IncludeData")
+    include_subordinates: Optional[bool] = Field(
+        default=False, alias="IncludeSubordinates"
+    )
     max_results: int = Field(default=5, ge=1, le=1000, alias="MaxResults")
     continuation_token: Optional[str] = Field(None, alias="ContinuationToken")
     labels: List[str] = Field(default_factory=list, alias="Labels")

--- a/src/litegraph/resources/admin.py
+++ b/src/litegraph/resources/admin.py
@@ -6,7 +6,7 @@ from ..mixins import (
     RetrievableAPIResource,
 )
 from ..models.backup import BackupModel
-from ..utils.url_helper import _get_url
+from ..utils.url_helper import _get_url_v1
 
 
 class Admin(
@@ -35,7 +35,7 @@ class Admin(
         """
         client = get_client()
 
-        url = _get_url(cls, "backups")
+        url = _get_url_v1(cls, "backups")
         try:
             client.request("POST", url, json={"Filename": filename})
             return True
@@ -109,7 +109,7 @@ class Admin(
         """
         client = get_client()
 
-        url = _get_url(cls, "backups")
+        url = _get_url_v1(cls, "flush")
         try:
             client.request("POST", url, json={})
             return True


### PR DESCRIPTION
Updated `retrieve`, `retrieve_all`, `enumerate`, and `search` methods to accept `include_data` and `include_subordinates` parameters. Modified `EnumerationQueryModel` to use Optional types for these fields. Adjusted URL helper calls to accommodate new parameters.